### PR TITLE
Backport: nmstate new function for default interface setting

### DIFF
--- a/pkg/nmstate/policy.go
+++ b/pkg/nmstate/policy.go
@@ -29,6 +29,7 @@ import (
 
 const (
 	nodeNetConfPolIntError      = "nodenetworkconfigurationpolicy 'interfaceName' cannot be empty"
+	nodeNetConfPolSelectorEmpty = "nodeNetworkConfigurationPolicy 'nodeSelector' cannot be empty map"
 	nodeNetConfPolAltnamesEmpty = "altnames cannot be empty array"
 	bondModeActiveBackup        = "active-backup"
 	interfaceTypeEthernet       = "ethernet"
@@ -99,7 +100,7 @@ func NewPolicyBuilder(apiClient *clients.Settings, name string, nodeSelector map
 	if len(nodeSelector) == 0 {
 		klog.V(100).Info("The nodeSelector of the NodeNetworkConfigurationPolicy is empty")
 
-		builder.errorMsg = "nodeNetworkConfigurationPolicy 'nodeSelector' cannot be empty map"
+		builder.errorMsg = nodeNetConfPolSelectorEmpty
 
 		return builder
 	}
@@ -660,6 +661,39 @@ func (builder *PolicyBuilder) WithEthernetIPv6LinkLocalInterface(interfaceName s
 		State: "up",
 		Ipv4: InterfaceIpv4{
 			Enabled: false,
+		},
+		Ipv6: InterfaceIpv6{
+			Enabled: true,
+		},
+	}
+
+	return builder.withInterface(newInterface)
+}
+
+// WithEthernetDualStackInterface appends the configuration for an ethernet interface with state "up",
+// IPv4 enabled, and IPv6 enabled to the NodeNetworkConfigurationPolicy.
+func (builder *PolicyBuilder) WithEthernetDualStackInterface(interfaceName string) *PolicyBuilder {
+	if valid, _ := builder.validate(); !valid {
+		return builder
+	}
+
+	klog.V(100).Infof("Creating NodeNetworkConfigurationPolicy %s with a dual-stack ethernet interface %s",
+		builder.Definition.Name, interfaceName)
+
+	if interfaceName == "" {
+		klog.V(100).Info("The interfaceName can not be empty string")
+
+		builder.errorMsg = nodeNetConfPolIntError
+
+		return builder
+	}
+
+	newInterface := NetworkInterface{
+		Name:  interfaceName,
+		Type:  interfaceTypeEthernet,
+		State: "up",
+		Ipv4: InterfaceIpv4{
+			Enabled: true,
 		},
 		Ipv6: InterfaceIpv6{
 			Enabled: true,

--- a/pkg/nmstate/policy_test.go
+++ b/pkg/nmstate/policy_test.go
@@ -870,6 +870,54 @@ func TestPolicyWithEthernetIPv6LinkLocalInterface(t *testing.T) {
 	}
 }
 
+func TestPolicyWithEthernetDualStackInterface(t *testing.T) {
+	testCases := []struct {
+		testNMStatePolicy *PolicyBuilder
+		expectedError     string
+		interfaceName     string
+	}{
+		{
+			testNMStatePolicy: buildValidPolicyTestBuilder(buildTestClientWithDummyPolicyObject()),
+			expectedError:     "",
+			interfaceName:     "ens1",
+		},
+		{
+			testNMStatePolicy: buildValidPolicyTestBuilder(buildTestClientWithDummyPolicyObject()),
+			expectedError:     nodeNetConfPolIntError,
+			interfaceName:     "",
+		},
+		{
+			testNMStatePolicy: buildInValidPolicyTestBuilder(buildTestClientWithDummyPolicyObject()),
+			expectedError:     "nodeNetworkConfigurationPolicy 'nodeSelector' cannot be empty map",
+			interfaceName:     "ens1",
+		},
+	}
+	for _, testCase := range testCases {
+		testPolicy := testCase.testNMStatePolicy.WithEthernetDualStackInterface(testCase.interfaceName)
+		assert.Equal(t, testCase.expectedError, testPolicy.errorMsg)
+
+		desireState := &DesiredState{}
+		if testCase.expectedError == "" {
+			_ = yaml.Unmarshal(testPolicy.Definition.Spec.DesiredState.Raw, desireState)
+			assert.Equal(t, &DesiredState{
+				Interfaces: []NetworkInterface{
+					{
+						Name:  testCase.interfaceName,
+						Type:  interfaceTypeEthernet,
+						State: "up",
+						Ipv4: InterfaceIpv4{
+							Enabled: true,
+						},
+						Ipv6: InterfaceIpv6{
+							Enabled: true,
+						},
+					},
+				},
+			}, desireState)
+		}
+	}
+}
+
 func TestPolicyWithAbsentInterface(t *testing.T) {
 	testCases := []struct {
 		testNMStatePolicy *PolicyBuilder


### PR DESCRIPTION
## Summary
- Backport of commit `14b82696` from `nmstatedefault` branch
- Adds `WithEthernetDualStackInterface` method to `PolicyBuilder` (IPv4 + IPv6 enabled, state "up")
- Adds `nodeNetConfPolSelectorEmpty` constant and uses it in `NewPolicyBuilder`
- Adds corresponding unit test `TestPolicyWithEthernetDualStackInterface`

## Test plan
- [x] `go build ./pkg/nmstate/...` passes
- [x] `go test ./pkg/nmstate/...` passes